### PR TITLE
Add server deployment guide for scaling to 200 instances with Nomad, Helm, and Waypoint

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,582 @@
+# Bolt.DIY Server Deployment Guide
+
+This guide provides instructions for deploying Bolt.DIY on servers to enable full Git functionality and scale to multiple instances.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Single Server Deployment](#single-server-deployment)
+- [Scaling to Multiple Instances](#scaling-to-multiple-instances)
+- [Kubernetes Deployment](#kubernetes-deployment)
+- [Server-Side Git Implementation](#server-side-git-implementation)
+- [Monitoring and Management](#monitoring-and-management)
+- [Security Considerations](#security-considerations)
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Kubernetes cluster (for multi-instance deployment)
+- GitHub Personal Access Token with appropriate permissions
+- Domain name and SSL certificates (for production)
+
+## Single Server Deployment
+
+### Option 1: Using Docker Compose
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/ABoringBusiness/bolt.diy.git
+   cd bolt.diy
+   ```
+
+2. Create a `.env.local` file with required environment variables:
+   ```bash
+   # GitHub Authentication
+   GITHUB_ACCESS_TOKEN=your_github_token
+   VITE_GITHUB_ACCESS_TOKEN=your_github_token
+   
+   # Optional: LLM API Keys
+   OPENAI_API_KEY=your_openai_key
+   ANTHROPIC_API_KEY=your_anthropic_key
+   # Add other API keys as needed
+   ```
+
+3. Build and start the container:
+   ```bash
+   docker-compose --profile production up -d
+   ```
+
+4. Access the application at `http://localhost:5173`
+
+### Option 2: Direct Server Deployment
+
+1. Install dependencies:
+   ```bash
+   # Install Node.js (v18+) and git
+   apt-get update
+   apt-get install -y nodejs npm git
+   
+   # Install pnpm
+   npm install -g pnpm
+   ```
+
+2. Clone and set up the repository:
+   ```bash
+   git clone https://github.com/ABoringBusiness/bolt.diy.git
+   cd bolt.diy
+   
+   # Create environment file
+   echo "GITHUB_ACCESS_TOKEN=your_github_token" > .env.local
+   echo "VITE_GITHUB_ACCESS_TOKEN=your_github_token" >> .env.local
+   
+   # Install dependencies
+   pnpm install
+   ```
+
+3. Build and run the application:
+   ```bash
+   # Build the application
+   pnpm run build
+   
+   # Start the server
+   pnpm run start:unix
+   ```
+
+## Scaling to Multiple Instances
+
+### Docker Swarm Deployment
+
+Docker Swarm provides a simple way to scale to multiple instances:
+
+1. Initialize a Docker Swarm:
+   ```bash
+   docker swarm init
+   ```
+
+2. Create a `docker-stack.yml` file:
+   ```yaml
+   version: '3.8'
+   
+   services:
+     bolt:
+       image: bolt-ai:production
+       build:
+         context: .
+         dockerfile: Dockerfile
+         target: bolt-ai-production
+       ports:
+         - "5173:5173"
+       env_file: .env.local
+       deploy:
+         replicas: 5  # Adjust as needed
+         update_config:
+           parallelism: 2
+           delay: 10s
+         restart_policy:
+           condition: on-failure
+       healthcheck:
+         test: ["CMD", "curl", "-f", "http://localhost:5173/health"]
+         interval: 30s
+         timeout: 10s
+         retries: 3
+   
+     nginx:
+       image: nginx:latest
+       ports:
+         - "80:80"
+         - "443:443"
+       volumes:
+         - ./nginx.conf:/etc/nginx/nginx.conf:ro
+         - ./ssl:/etc/nginx/ssl:ro
+       depends_on:
+         - bolt
+       deploy:
+         replicas: 1
+   ```
+
+3. Create an Nginx configuration for load balancing:
+   ```nginx
+   # nginx.conf
+   events {
+     worker_connections 1024;
+   }
+   
+   http {
+     upstream bolt_servers {
+       server bolt:5173;
+     }
+     
+     server {
+       listen 80;
+       server_name your-domain.com;
+       
+       location / {
+         proxy_pass http://bolt_servers;
+         proxy_http_version 1.1;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection 'upgrade';
+         proxy_set_header Host $host;
+         proxy_cache_bypass $http_upgrade;
+       }
+     }
+   }
+   ```
+
+4. Deploy the stack:
+   ```bash
+   docker stack deploy -c docker-stack.yml bolt
+   ```
+
+5. Scale the service:
+   ```bash
+   docker service scale bolt_bolt=10
+   ```
+
+## Kubernetes Deployment
+
+For large-scale deployments (200+ instances), Kubernetes is recommended:
+
+1. Create a `deployment.yaml` file:
+   ```yaml
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: bolt-diy
+   spec:
+     replicas: 200  # Scale to 200 instances
+     selector:
+       matchLabels:
+         app: bolt-diy
+     template:
+       metadata:
+         labels:
+           app: bolt-diy
+       spec:
+         containers:
+         - name: bolt-diy
+           image: bolt-ai:production
+           ports:
+           - containerPort: 5173
+           env:
+           - name: GITHUB_ACCESS_TOKEN
+             valueFrom:
+               secretKeyRef:
+                 name: bolt-secrets
+                 key: github-token
+           # Add other environment variables as needed
+           resources:
+             limits:
+               cpu: "1"
+               memory: "1Gi"
+             requests:
+               cpu: "500m"
+               memory: "512Mi"
+           livenessProbe:
+             httpGet:
+               path: /health
+               port: 5173
+             initialDelaySeconds: 30
+             periodSeconds: 10
+           readinessProbe:
+             httpGet:
+               path: /health
+               port: 5173
+             initialDelaySeconds: 5
+             periodSeconds: 5
+   ---
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: bolt-diy-service
+   spec:
+     selector:
+       app: bolt-diy
+     ports:
+     - port: 80
+       targetPort: 5173
+     type: LoadBalancer
+   ```
+
+2. Create a secret for sensitive information:
+   ```bash
+   kubectl create secret generic bolt-secrets \
+     --from-literal=github-token=your_github_token \
+     --from-literal=openai-key=your_openai_key
+   ```
+
+3. Apply the configuration:
+   ```bash
+   kubectl apply -f deployment.yaml
+   ```
+
+4. Set up horizontal pod autoscaling:
+   ```yaml
+   apiVersion: autoscaling/v2
+   kind: HorizontalPodAutoscaler
+   metadata:
+     name: bolt-diy-hpa
+   spec:
+     scaleTargetRef:
+       apiVersion: apps/v1
+       kind: Deployment
+       name: bolt-diy
+     minReplicas: 50
+     maxReplicas: 250
+     metrics:
+     - type: Resource
+       resource:
+         name: cpu
+         target:
+           type: Utilization
+           averageUtilization: 70
+   ```
+
+## Server-Side Git Implementation
+
+To enable proper Git functionality, add a server-side Git API:
+
+1. Create a new file `app/routes/api.server-git.ts`:
+
+```typescript
+import { json } from '@remix-run/cloudflare';
+import type { ActionFunctionArgs } from '@remix-run/cloudflare';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import ignore from 'ignore';
+
+const execAsync = promisify(exec);
+
+// Define ignore patterns for repository files
+const IGNORE_PATTERNS = [
+  'node_modules/**',
+  '.git/**',
+  '.github/**',
+  '.vscode/**',
+  'dist/**',
+  'build/**',
+  '.next/**',
+  'coverage/**',
+  '.cache/**',
+  '.idea/**',
+  '**/*.log',
+  '**/.DS_Store',
+  '**/npm-debug.log*',
+  '**/yarn-debug.log*',
+  '**/yarn-error.log*',
+  '**/*lock.json',
+  '**/*lock.yaml',
+];
+
+const MAX_FILE_SIZE = 100 * 1024; // 100KB limit per file
+const MAX_TOTAL_SIZE = 500 * 1024; // 500KB total limit
+
+export async function action({ request }: ActionFunctionArgs) {
+  const { repoUrl } = await request.json();
+  
+  if (!repoUrl) {
+    return json({ error: 'Repository URL is required' }, { status: 400 });
+  }
+  
+  try {
+    // Create a unique temporary directory
+    const tempDir = path.join(process.cwd(), 'tmp', Date.now().toString());
+    fs.mkdirSync(tempDir, { recursive: true });
+    
+    // Clone the repository
+    const gitToken = process.env.GITHUB_ACCESS_TOKEN;
+    let cloneUrl = repoUrl;
+    
+    // Add token to URL if it's a GitHub repository
+    if (gitToken && repoUrl.includes('github.com')) {
+      const urlObj = new URL(repoUrl);
+      urlObj.username = gitToken;
+      cloneUrl = urlObj.toString();
+    }
+    
+    await execAsync(`git clone --depth 1 ${cloneUrl} ${tempDir}`);
+    
+    // Read repository files
+    const ig = ignore().add(IGNORE_PATTERNS);
+    const files = [];
+    let totalSize = 0;
+    const skippedFiles = [];
+    
+    // Walk through the directory and collect files
+    const walkDir = (dir, baseDir = '') => {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        const relativePath = path.join(baseDir, entry.name);
+        
+        // Skip ignored files
+        if (ig.ignores(relativePath)) {
+          continue;
+        }
+        
+        if (entry.isDirectory()) {
+          walkDir(fullPath, relativePath);
+        } else {
+          try {
+            const stats = fs.statSync(fullPath);
+            
+            // Skip large files
+            if (stats.size > MAX_FILE_SIZE) {
+              skippedFiles.push(`${relativePath} (too large: ${Math.round(stats.size / 1024)}KB)`);
+              continue;
+            }
+            
+            // Check total size limit
+            if (totalSize + stats.size > MAX_TOTAL_SIZE) {
+              skippedFiles.push(`${relativePath} (would exceed total size limit)`);
+              continue;
+            }
+            
+            // Read file content
+            const content = fs.readFileSync(fullPath, 'utf8');
+            totalSize += stats.size;
+            
+            files.push({
+              path: relativePath,
+              content,
+              size: stats.size
+            });
+          } catch (error) {
+            skippedFiles.push(`${relativePath} (error: ${error.message})`);
+          }
+        }
+      }
+    };
+    
+    walkDir(tempDir);
+    
+    // Clean up temporary directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    
+    return json({
+      success: true,
+      files,
+      skippedFiles,
+      totalSize,
+      repoUrl
+    });
+  } catch (error) {
+    console.error('Git clone error:', error);
+    return json({
+      error: 'Failed to clone repository',
+      message: error.message
+    }, { status: 500 });
+  }
+}
+```
+
+2. Update the client-side code in `app/components/git/GitUrlImport.client.tsx`:
+
+```typescript
+// Modify the importRepo function
+const importRepo = async (repoUrl?: string) => {
+  if (!repoUrl) {
+    return;
+  }
+
+  setLoading(true);
+
+  try {
+    // Use the server-side Git API
+    const response = await fetch('/api/server-git', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoUrl })
+    });
+    
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || 'Failed to import repository');
+    }
+    
+    const { files, skippedFiles, totalSize, repoUrl: clonedRepoUrl } = await response.json();
+    
+    if (importChat) {
+      const fileContents = files.map(file => ({
+        path: file.path,
+        content: file.content
+      }));
+      
+      const commands = await detectProjectCommands(fileContents);
+      const commandsMessage = createCommandsMessage(commands);
+      
+      const filesMessage = {
+        role: 'assistant',
+        content: `Cloning the repo ${clonedRepoUrl}
+${skippedFiles.length > 0 ? `\nSkipped files (${skippedFiles.length}):\n${skippedFiles.map(f => `- ${f}`).join('\n')}` : ''}
+
+<boltArtifact id="imported-files" title="Git Cloned Files" type="bundled">
+${fileContents.map(file => 
+  `<boltAction type="file" filePath="${file.path}">
+${escapeBoltTags(file.content)}
+</boltAction>`).join('\n')}
+</boltArtifact>`,
+        id: generateId(),
+        createdAt: new Date(),
+      };
+      
+      const messages = [filesMessage];
+      
+      if (commandsMessage) {
+        messages.push({
+          role: 'user',
+          id: generateId(),
+          content: 'Setup the codebase and Start the application',
+        });
+        messages.push(commandsMessage);
+      }
+      
+      await importChat(`Git Project:${clonedRepoUrl.split('/').slice(-1)[0]}`, messages, { gitUrl: clonedRepoUrl });
+    }
+  } catch (error) {
+    console.error('Error during import:', error);
+    toast.error(`Failed to import repository: ${error.message || 'Unknown error'}`);
+  } finally {
+    setLoading(false);
+  }
+};
+```
+
+## Monitoring and Management
+
+For managing 200+ instances, implement proper monitoring:
+
+1. **Prometheus and Grafana**:
+   - Add a `/metrics` endpoint to the application
+   - Deploy Prometheus to collect metrics
+   - Set up Grafana dashboards for visualization
+
+2. **Centralized Logging**:
+   - Implement ELK stack (Elasticsearch, Logstash, Kibana)
+   - Configure log forwarding from all instances
+
+3. **Health Checks**:
+   - Add a `/health` endpoint to the application
+   - Implement both liveness and readiness probes
+
+## Security Considerations
+
+1. **GitHub Token Security**:
+   - Use environment variables for tokens
+   - Consider using GitHub Apps instead of personal access tokens
+   - Implement token rotation
+
+2. **Rate Limiting**:
+   - Add rate limiting to the Git API endpoints
+   - Implement IP-based rate limiting for public instances
+
+3. **Resource Management**:
+   - Set resource limits for containers
+   - Implement auto-scaling based on resource usage
+
+4. **Network Security**:
+   - Use a private network for communication between instances
+   - Implement a Web Application Firewall (WAF)
+   - Use HTTPS for all traffic
+
+## Automation Scripts
+
+### Deployment Script
+
+Create a `deploy.sh` script for easy deployment:
+
+```bash
+#!/bin/bash
+
+# Configuration
+INSTANCES=${1:-1}
+BASE_PORT=5173
+GITHUB_TOKEN=${GITHUB_TOKEN:-""}
+
+# Check if GitHub token is provided
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Warning: GITHUB_TOKEN not set. Git functionality may be limited."
+fi
+
+# Create .env.local file
+cat > .env.local << EOF
+GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN
+VITE_GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN
+EOF
+
+# Build the Docker image
+docker build -t bolt-ai:production --target bolt-ai-production .
+
+# Deploy instances
+for i in $(seq 1 $INSTANCES); do
+  PORT=$((BASE_PORT + i - 1))
+  CONTAINER_NAME="bolt-instance-$i"
+  
+  echo "Starting instance $i on port $PORT..."
+  docker run -d \
+    --name $CONTAINER_NAME \
+    -p $PORT:5173 \
+    --env-file .env.local \
+    -e INSTANCE_ID=$i \
+    bolt-ai:production
+done
+
+echo "Deployed $INSTANCES instances of Bolt.DIY"
+echo "Access the first instance at http://localhost:$BASE_PORT"
+```
+
+Make the script executable:
+```bash
+chmod +x deploy.sh
+```
+
+Usage:
+```bash
+# Deploy 5 instances
+./deploy.sh 5
+
+# Deploy 200 instances (for large servers)
+./deploy.sh 200
+```

--- a/NOMAD_HELM_DEPLOYMENT.md
+++ b/NOMAD_HELM_DEPLOYMENT.md
@@ -1,0 +1,211 @@
+# Bolt.DIY Deployment with Nomad and Helm
+
+This guide provides instructions for deploying Bolt.DIY using HashiCorp Nomad and Helm charts.
+
+## Nomad Deployment
+
+[HashiCorp Nomad](https://www.nomadproject.io/) is a flexible workload orchestrator that enables an organization to easily deploy and manage any containerized or legacy application using a single, unified workflow.
+
+### Prerequisites
+
+- Nomad cluster (version 1.4.0+)
+- Consul for service discovery
+- Docker for container runtime
+- Vault for secrets management (optional but recommended)
+
+### Deployment Steps
+
+1. **Configure Vault for Secrets (Optional but Recommended)**
+
+   ```bash
+   # Store GitHub token and other sensitive data in Vault
+   vault kv put secret/bolt-diy \
+     github_token=your_github_token \
+     openai_key=your_openai_key \
+     anthropic_key=your_anthropic_key
+   ```
+
+2. **Deploy the Nomad Job**
+
+   ```bash
+   # Deploy the job
+   nomad job run nomad/bolt.nomad.hcl
+   
+   # Verify the deployment
+   nomad job status bolt-diy
+   ```
+
+3. **Scale the Deployment**
+
+   ```bash
+   # Scale to a specific count
+   nomad job scale bolt-diy bolt-app 100
+   ```
+
+### Using Waypoint with Nomad
+
+[Waypoint](https://www.waypointproject.io/) provides a consistent workflow to build, deploy, and release applications across any platform.
+
+1. **Install Waypoint**
+
+   ```bash
+   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+   sudo apt-get update && sudo apt-get install waypoint
+   ```
+
+2. **Initialize Waypoint**
+
+   ```bash
+   waypoint init
+   ```
+
+3. **Deploy with Waypoint**
+
+   ```bash
+   waypoint up
+   ```
+
+4. **View Deployment Status**
+
+   ```bash
+   waypoint status
+   ```
+
+## Helm Chart Deployment
+
+[Helm](https://helm.sh/) is the package manager for Kubernetes that helps you define, install, and upgrade Kubernetes applications.
+
+### Prerequisites
+
+- Kubernetes cluster (version 1.19+)
+- Helm (version 3.0+)
+- kubectl configured to communicate with your cluster
+
+### Deployment Steps
+
+1. **Configure Values**
+
+   Create a custom values file (`my-values.yaml`) to override default settings:
+
+   ```yaml
+   replicaCount: 50  # Start with 50 instances
+
+   ingress:
+     hosts:
+       - host: bolt.yourdomain.com
+         paths:
+           - path: /
+             pathType: Prefix
+
+   secretEnv:
+     GITHUB_ACCESS_TOKEN: "your_github_token"
+     VITE_GITHUB_ACCESS_TOKEN: "your_github_token"
+     OPENAI_API_KEY: "your_openai_key"
+     ANTHROPIC_API_KEY: "your_anthropic_key"
+   ```
+
+2. **Install the Helm Chart**
+
+   ```bash
+   # Add the Helm repository (if hosted in a repository)
+   # helm repo add bolt-repo https://your-helm-repo.example.com
+   # helm repo update
+
+   # Install from local chart
+   helm install bolt-diy ./helm/bolt-diy -f my-values.yaml
+   ```
+
+3. **Verify the Deployment**
+
+   ```bash
+   # Check deployment status
+   helm status bolt-diy
+   
+   # Check pods
+   kubectl get pods -l app.kubernetes.io/name=bolt-diy
+   ```
+
+4. **Scale the Deployment**
+
+   ```bash
+   # Scale manually
+   kubectl scale deployment bolt-diy --replicas=200
+   
+   # The HorizontalPodAutoscaler will automatically scale between 
+   # minReplicas and maxReplicas based on CPU/memory usage
+   ```
+
+5. **Upgrade the Deployment**
+
+   ```bash
+   # Update values and upgrade
+   helm upgrade bolt-diy ./helm/bolt-diy -f my-values.yaml
+   ```
+
+## Scaling to 200 Instances
+
+Both Nomad and Kubernetes (with Helm) support scaling to 200 instances. Here are some considerations:
+
+### Resource Planning
+
+For 200 instances with the recommended resources:
+- CPU: 200 × 0.5 cores = 100 CPU cores
+- Memory: 200 × 512 MB = 100 GB RAM
+
+Ensure your infrastructure can handle this load.
+
+### Load Balancing
+
+- **Nomad**: Uses Consul for service discovery and Nginx/Traefik for load balancing
+- **Kubernetes**: Uses Service/Ingress resources for load balancing
+
+### Monitoring
+
+Set up proper monitoring for both platforms:
+
+- **Nomad**: Prometheus + Grafana with Nomad exporters
+- **Kubernetes**: Prometheus Operator + Grafana
+
+### Autoscaling
+
+Both platforms support autoscaling:
+
+- **Nomad**: Uses the scaling stanza with Prometheus metrics
+- **Kubernetes**: Uses HorizontalPodAutoscaler with CPU/memory metrics
+
+## Troubleshooting
+
+### Nomad
+
+```bash
+# Check job status
+nomad job status bolt-diy
+
+# View allocation logs
+nomad alloc logs -f <allocation_id>
+
+# Check Consul service health
+consul catalog services
+consul health service bolt-diy
+```
+
+### Kubernetes/Helm
+
+```bash
+# Check pod status
+kubectl get pods -l app.kubernetes.io/name=bolt-diy
+
+# View pod logs
+kubectl logs -l app.kubernetes.io/name=bolt-diy
+
+# Check service and ingress
+kubectl get svc,ing -l app.kubernetes.io/name=bolt-diy
+```
+
+## Additional Resources
+
+- [Nomad Documentation](https://www.nomadproject.io/docs)
+- [Waypoint Documentation](https://www.waypointproject.io/docs)
+- [Helm Documentation](https://helm.sh/docs/)
+- [Kubernetes Documentation](https://kubernetes.io/docs/)

--- a/SERVER_DEPLOYMENT.md
+++ b/SERVER_DEPLOYMENT.md
@@ -1,0 +1,96 @@
+# Bolt.DIY Server Deployment
+
+This guide provides quick instructions for deploying Bolt.DIY on a server to enable full Git functionality.
+
+## Quick Start
+
+### Single Server Deployment
+
+```bash
+# Clone the repository
+git clone https://github.com/ABoringBusiness/bolt.diy.git
+cd bolt.diy
+
+# Set your GitHub token
+export GITHUB_TOKEN=your_github_token
+
+# Deploy a single instance
+./deploy.sh 1
+```
+
+### Multiple Instances (Docker Swarm)
+
+```bash
+# Initialize Docker Swarm
+docker swarm init
+
+# Create environment file
+echo "GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN" > .env.local
+echo "VITE_GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN" >> .env.local
+
+# Deploy the stack
+docker stack deploy -c docker-stack.yml bolt
+
+# Scale to desired number of instances
+docker service scale bolt_bolt=10
+```
+
+### Large-Scale Deployment (Kubernetes)
+
+```bash
+# Create GitHub token secret
+kubectl create secret generic bolt-secrets \
+  --from-literal=github-token=$GITHUB_TOKEN
+
+# Apply the deployment configuration
+kubectl apply -f kubernetes/deployment.yaml
+```
+
+## Server-Side Git Implementation
+
+This deployment includes a server-side Git implementation that enables proper Git functionality by:
+
+1. Cloning repositories on the server using native Git
+2. Processing repository files server-side
+3. Returning only the necessary files to the client
+
+This approach bypasses the browser environment limitations that prevent GitHub imports from working in browser-only environments like bolt.new.
+
+## Scaling to 200 Instances
+
+For large-scale deployments (200+ instances), we recommend:
+
+1. Using Kubernetes with horizontal pod autoscaling
+2. Implementing a proper load balancing strategy
+3. Setting up centralized logging and monitoring
+4. Using a distributed file system for shared storage
+
+See the full [DEPLOYMENT.md](DEPLOYMENT.md) for detailed instructions.
+
+## Monitoring
+
+Access the health endpoint to check instance status:
+
+```
+http://your-server:5173/health
+```
+
+This returns:
+```json
+{
+  "status": "ok",
+  "version": "0.0.7",
+  "instanceId": "1",
+  "uptime": 3600000,
+  "timestamp": "2025-04-05T12:34:56.789Z"
+}
+```
+
+## Security Considerations
+
+1. Store GitHub tokens securely using environment variables or secrets
+2. Implement proper rate limiting for the Git API
+3. Use HTTPS for all traffic
+4. Regularly rotate credentials
+
+For more detailed deployment instructions, see [DEPLOYMENT.md](DEPLOYMENT.md).

--- a/app/routes/api.server-git.ts
+++ b/app/routes/api.server-git.ts
@@ -1,0 +1,132 @@
+import { json } from '@remix-run/cloudflare';
+import type { ActionFunctionArgs } from '@remix-run/cloudflare';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import ignore from 'ignore';
+
+const execAsync = promisify(exec);
+
+// Define ignore patterns for repository files
+const IGNORE_PATTERNS = [
+  'node_modules/**',
+  '.git/**',
+  '.github/**',
+  '.vscode/**',
+  'dist/**',
+  'build/**',
+  '.next/**',
+  'coverage/**',
+  '.cache/**',
+  '.idea/**',
+  '**/*.log',
+  '**/.DS_Store',
+  '**/npm-debug.log*',
+  '**/yarn-debug.log*',
+  '**/yarn-error.log*',
+  '**/*lock.json',
+  '**/*lock.yaml',
+];
+
+const MAX_FILE_SIZE = 100 * 1024; // 100KB limit per file
+const MAX_TOTAL_SIZE = 500 * 1024; // 500KB total limit
+
+export async function action({ request }: ActionFunctionArgs) {
+  const { repoUrl } = await request.json();
+  
+  if (!repoUrl) {
+    return json({ error: 'Repository URL is required' }, { status: 400 });
+  }
+  
+  try {
+    // Create a unique temporary directory
+    const tempDir = path.join(process.cwd(), 'tmp', Date.now().toString());
+    fs.mkdirSync(tempDir, { recursive: true });
+    
+    // Clone the repository
+    const gitToken = process.env.GITHUB_ACCESS_TOKEN;
+    let cloneUrl = repoUrl;
+    
+    // Add token to URL if it's a GitHub repository
+    if (gitToken && repoUrl.includes('github.com')) {
+      const urlObj = new URL(repoUrl);
+      urlObj.username = gitToken;
+      cloneUrl = urlObj.toString();
+    }
+    
+    await execAsync(`git clone --depth 1 ${cloneUrl} ${tempDir}`);
+    
+    // Read repository files
+    const ig = ignore().add(IGNORE_PATTERNS);
+    const files = [];
+    let totalSize = 0;
+    const skippedFiles = [];
+    
+    // Walk through the directory and collect files
+    const walkDir = (dir, baseDir = '') => {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        const relativePath = path.join(baseDir, entry.name);
+        
+        // Skip ignored files
+        if (ig.ignores(relativePath)) {
+          continue;
+        }
+        
+        if (entry.isDirectory()) {
+          walkDir(fullPath, relativePath);
+        } else {
+          try {
+            const stats = fs.statSync(fullPath);
+            
+            // Skip large files
+            if (stats.size > MAX_FILE_SIZE) {
+              skippedFiles.push(`${relativePath} (too large: ${Math.round(stats.size / 1024)}KB)`);
+              continue;
+            }
+            
+            // Check total size limit
+            if (totalSize + stats.size > MAX_TOTAL_SIZE) {
+              skippedFiles.push(`${relativePath} (would exceed total size limit)`);
+              continue;
+            }
+            
+            // Read file content
+            const content = fs.readFileSync(fullPath, 'utf8');
+            totalSize += stats.size;
+            
+            files.push({
+              path: relativePath,
+              content,
+              size: stats.size
+            });
+          } catch (error) {
+            skippedFiles.push(`${relativePath} (error: ${error.message})`);
+          }
+        }
+      }
+    };
+    
+    walkDir(tempDir);
+    
+    // Clean up temporary directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    
+    return json({
+      success: true,
+      files,
+      skippedFiles,
+      totalSize,
+      repoUrl
+    });
+  } catch (error) {
+    console.error('Git clone error:', error);
+    return json({
+      error: 'Failed to clone repository',
+      message: error.message
+    }, { status: 500 });
+  }
+}

--- a/app/routes/health.ts
+++ b/app/routes/health.ts
@@ -1,0 +1,16 @@
+import { json } from '@remix-run/cloudflare';
+import type { LoaderFunctionArgs } from '@remix-run/cloudflare';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const instanceId = process.env.INSTANCE_ID || 'default';
+  const startTime = global.__startTime || Date.now();
+  const uptime = Date.now() - startTime;
+  
+  return json({
+    status: 'ok',
+    version: process.env.npm_package_version || '0.0.0',
+    instanceId,
+    uptime,
+    timestamp: new Date().toISOString()
+  });
+}

--- a/deploy-helm.sh
+++ b/deploy-helm.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Configuration
+INSTANCES=${1:-200}
+GITHUB_TOKEN=${GITHUB_TOKEN:-""}
+NAMESPACE=${NAMESPACE:-"default"}
+RELEASE_NAME=${RELEASE_NAME:-"bolt-diy"}
+DOMAIN=${DOMAIN:-"bolt.example.com"}
+
+# Check if Helm is installed
+if ! command -v helm &> /dev/null; then
+    echo "Helm is not installed. Please install Helm first."
+    exit 1
+fi
+
+# Check if kubectl is installed
+if ! command -v kubectl &> /dev/null; then
+    echo "kubectl is not installed. Please install kubectl first."
+    exit 1
+fi
+
+# Check if GitHub token is provided
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Warning: GITHUB_TOKEN not set. Git functionality may be limited."
+fi
+
+# Create values file
+TMP_VALUES_FILE=$(mktemp)
+cat > $TMP_VALUES_FILE << EOF
+replicaCount: $INSTANCES
+
+ingress:
+  enabled: true
+  hosts:
+    - host: $DOMAIN
+      paths:
+        - path: /
+          pathType: Prefix
+
+secretEnv:
+  GITHUB_ACCESS_TOKEN: "$GITHUB_TOKEN"
+  VITE_GITHUB_ACCESS_TOKEN: "$GITHUB_TOKEN"
+  OPENAI_API_KEY: "${OPENAI_API_KEY:-""}"
+  ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-""}"
+EOF
+
+# Deploy using Helm
+echo "Deploying $INSTANCES instances using Helm..."
+helm upgrade --install $RELEASE_NAME ./helm/bolt-diy \
+  --namespace $NAMESPACE \
+  --create-namespace \
+  -f $TMP_VALUES_FILE
+
+# Clean up
+rm $TMP_VALUES_FILE
+
+echo "Deployment initiated. Check status with: helm status $RELEASE_NAME -n $NAMESPACE"

--- a/deploy-nomad.sh
+++ b/deploy-nomad.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Configuration
+INSTANCES=${1:-200}
+GITHUB_TOKEN=${GITHUB_TOKEN:-""}
+DATACENTER=${DATACENTER:-"dc1"}
+
+# Check if Nomad is installed
+if ! command -v nomad &> /dev/null; then
+    echo "Nomad is not installed. Please install Nomad first."
+    exit 1
+fi
+
+# Check if GitHub token is provided
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Warning: GITHUB_TOKEN not set. Git functionality may be limited."
+fi
+
+# Check if Vault is installed and store secrets
+if command -v vault &> /dev/null; then
+    echo "Storing secrets in Vault..."
+    vault kv put secret/bolt-diy \
+        github_token="$GITHUB_TOKEN" \
+        openai_key="${OPENAI_API_KEY:-""}" \
+        anthropic_key="${ANTHROPIC_API_KEY:-""}"
+else
+    echo "Vault not found. Secrets will be passed directly to Nomad."
+fi
+
+# Create a temporary Nomad job file with the correct instance count
+TMP_JOB_FILE=$(mktemp)
+cat nomad/bolt.nomad.hcl | sed "s/count = 200/count = $INSTANCES/" | sed "s/datacenters = \[\"dc1\"\]/datacenters = \[\"$DATACENTER\"\]/" > $TMP_JOB_FILE
+
+# Deploy to Nomad
+echo "Deploying $INSTANCES instances to Nomad..."
+nomad job run $TMP_JOB_FILE
+
+# Clean up
+rm $TMP_JOB_FILE
+
+echo "Deployment initiated. Check status with: nomad job status bolt-diy"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Configuration
+INSTANCES=${1:-1}
+BASE_PORT=5173
+GITHUB_TOKEN=${GITHUB_TOKEN:-""}
+
+# Check if GitHub token is provided
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Warning: GITHUB_TOKEN not set. Git functionality may be limited."
+fi
+
+# Create .env.local file
+cat > .env.local << EOF
+GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN
+VITE_GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN
+EOF
+
+# Build the Docker image
+docker build -t bolt-ai:production --target bolt-ai-production .
+
+# Deploy instances
+for i in $(seq 1 $INSTANCES); do
+  PORT=$((BASE_PORT + i - 1))
+  CONTAINER_NAME="bolt-instance-$i"
+  
+  echo "Starting instance $i on port $PORT..."
+  docker run -d \
+    --name $CONTAINER_NAME \
+    -p $PORT:5173 \
+    --env-file .env.local \
+    -e INSTANCE_ID=$i \
+    bolt-ai:production
+done
+
+echo "Deployed $INSTANCES instances of Bolt.DIY"
+echo "Access the first instance at http://localhost:$BASE_PORT"

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  bolt:
+    image: bolt-ai:production
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: bolt-ai-production
+    ports:
+      - "5173:5173"
+    env_file: .env.local
+    environment:
+      - NODE_ENV=production
+      - RUNNING_IN_DOCKER=true
+    deploy:
+      replicas: 5  # Adjust as needed
+      update_config:
+        parallelism: 2
+        delay: 10s
+      restart_policy:
+        condition: on-failure
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5173/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    depends_on:
+      - bolt
+    deploy:
+      replicas: 1

--- a/helm/bolt-diy/Chart.yaml
+++ b/helm/bolt-diy/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: bolt-diy
+description: A Helm chart for Bolt.DIY application
+type: application
+version: 0.1.0
+appVersion: "0.0.7"
+maintainers:
+  - name: Bolt.DIY Team
+    email: maintainers@bolt.diy

--- a/helm/bolt-diy/templates/_helpers.tpl
+++ b/helm/bolt-diy/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bolt-diy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bolt-diy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bolt-diy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bolt-diy.labels" -}}
+helm.sh/chart: {{ include "bolt-diy.chart" . }}
+{{ include "bolt-diy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bolt-diy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bolt-diy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bolt-diy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bolt-diy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/bolt-diy/templates/deployment.yaml
+++ b/helm/bolt-diy/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bolt-diy.fullname" . }}
+  labels:
+    {{- include "bolt-diy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "bolt-diy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "bolt-diy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "bolt-diy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 5173
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            - name: INSTANCE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          envFrom:
+            - secretRef:
+                name: {{ include "bolt-diy.fullname" . }}-secrets
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/bolt-diy/templates/hpa.yaml
+++ b/helm/bolt-diy/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bolt-diy.fullname" . }}
+  labels:
+    {{- include "bolt-diy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bolt-diy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/bolt-diy/templates/ingress.yaml
+++ b/helm/bolt-diy/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "bolt-diy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "bolt-diy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/bolt-diy/templates/secrets.yaml
+++ b/helm/bolt-diy/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "bolt-diy.fullname" . }}-secrets
+  labels:
+    {{- include "bolt-diy.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}

--- a/helm/bolt-diy/templates/service.yaml
+++ b/helm/bolt-diy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bolt-diy.fullname" . }}
+  labels:
+    {{- include "bolt-diy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "bolt-diy.selectorLabels" . | nindent 4 }}

--- a/helm/bolt-diy/templates/serviceaccount.yaml
+++ b/helm/bolt-diy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bolt-diy.serviceAccountName" . }}
+  labels:
+    {{- include "bolt-diy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/bolt-diy/values.yaml
+++ b/helm/bolt-diy/values.yaml
@@ -1,0 +1,99 @@
+# Default values for bolt-diy.
+# This is a YAML-formatted file.
+
+replicaCount: 200
+
+image:
+  repository: bolt-ai
+  tag: production
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 5173
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  hosts:
+    - host: bolt.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: bolt-tls
+  #    hosts:
+  #      - bolt.example.com
+
+resources:
+  limits:
+    cpu: 1
+    memory: 1Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 50
+  maxReplicas: 250
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Environment variables
+env:
+  NODE_ENV: production
+  RUNNING_IN_DOCKER: "true"
+
+# Secret environment variables (will be stored in a Kubernetes Secret)
+secretEnv:
+  GITHUB_ACCESS_TOKEN: ""
+  VITE_GITHUB_ACCESS_TOKEN: ""
+  OPENAI_API_KEY: ""
+  ANTHROPIC_API_KEY: ""
+
+# Configure the health check endpoint
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 5173
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 5173
+  initialDelaySeconds: 5
+  periodSeconds: 5

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bolt-diy
+spec:
+  replicas: 200  # Scale to 200 instances
+  selector:
+    matchLabels:
+      app: bolt-diy
+  template:
+    metadata:
+      labels:
+        app: bolt-diy
+    spec:
+      containers:
+      - name: bolt-diy
+        image: bolt-ai:production
+        ports:
+        - containerPort: 5173
+        env:
+        - name: GITHUB_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: bolt-secrets
+              key: github-token
+        # Add other environment variables as needed
+        resources:
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+          requests:
+            cpu: "500m"
+            memory: "512Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 5173
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 5173
+          initialDelaySeconds: 5
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bolt-diy-service
+spec:
+  selector:
+    app: bolt-diy
+  ports:
+  - port: 80
+    targetPort: 5173
+  type: LoadBalancer
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: bolt-diy-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bolt-diy
+  minReplicas: 50
+  maxReplicas: 250
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,29 @@
+events {
+  worker_connections 1024;
+}
+
+http {
+  upstream bolt_servers {
+    server bolt:5173;
+  }
+  
+  server {
+    listen 80;
+    server_name localhost;
+    
+    location / {
+      proxy_pass http://bolt_servers;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection 'upgrade';
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
+    
+    location /health {
+      proxy_pass http://bolt_servers/health;
+      access_log off;
+      add_header Cache-Control no-cache;
+    }
+  }
+}

--- a/nomad/bolt.nomad.hcl
+++ b/nomad/bolt.nomad.hcl
@@ -1,0 +1,161 @@
+job "bolt-diy" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "bolt-app" {
+    count = 200  # Scale to 200 instances
+
+    network {
+      port "http" {
+        to = 5173
+      }
+    }
+
+    service {
+      name = "bolt-diy"
+      port = "http"
+      
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.bolt.rule=Host(`bolt.example.com`)",
+      ]
+
+      check {
+        type     = "http"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "bolt" {
+      driver = "docker"
+
+      config {
+        image = "bolt-ai:production"
+        ports = ["http"]
+      }
+
+      env {
+        NODE_ENV = "production"
+        RUNNING_IN_DOCKER = "true"
+        INSTANCE_ID = "${NOMAD_ALLOC_INDEX}"
+      }
+
+      template {
+        data = <<EOH
+{{ with secret "secret/bolt-diy" }}
+GITHUB_ACCESS_TOKEN={{ .Data.github_token }}
+VITE_GITHUB_ACCESS_TOKEN={{ .Data.github_token }}
+OPENAI_API_KEY={{ .Data.openai_key }}
+ANTHROPIC_API_KEY={{ .Data.anthropic_key }}
+{{ end }}
+EOH
+        destination = "secrets/env.vars"
+        env         = true
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+    }
+
+    scaling {
+      enabled = true
+      min     = 50
+      max     = 250
+      
+      policy {
+        cooldown = "1m"
+        
+        check "cpu" {
+          source = "prometheus"
+          query  = "avg(nomad_client_allocs_cpu_total_percent{task='bolt'})"
+          
+          strategy "target-value" {
+            target = 70
+          }
+        }
+      }
+    }
+  }
+
+  group "nginx" {
+    count = 1
+
+    network {
+      port "http" {
+        static = 80
+      }
+      port "https" {
+        static = 443
+      }
+    }
+
+    service {
+      name = "bolt-nginx"
+      port = "http"
+      
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.bolt-nginx.rule=Host(`bolt.example.com`)",
+      ]
+    }
+
+    task "nginx" {
+      driver = "docker"
+
+      config {
+        image = "nginx:latest"
+        ports = ["http", "https"]
+        
+        volumes = [
+          "local/nginx.conf:/etc/nginx/nginx.conf:ro",
+        ]
+      }
+
+      template {
+        data = <<EOF
+events {
+  worker_connections 1024;
+}
+
+http {
+  upstream bolt_servers {
+    {{range service "bolt-diy"}}
+    server {{.Address}}:{{.Port}};
+    {{end}}
+  }
+  
+  server {
+    listen 80;
+    server_name localhost;
+    
+    location / {
+      proxy_pass http://bolt_servers;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection 'upgrade';
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
+    
+    location /health {
+      proxy_pass http://bolt_servers/health;
+      access_log off;
+      add_header Cache-Control no-cache;
+    }
+  }
+}
+EOF
+        destination = "local/nginx.conf"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -1,0 +1,47 @@
+project = "bolt-diy"
+
+app "bolt-diy" {
+  labels = {
+    "service" = "bolt-diy",
+    "env"     = "production"
+  }
+
+  build {
+    use "docker" {
+      dockerfile = "${path.app}/Dockerfile"
+      target     = "bolt-ai-production"
+    }
+    
+    registry {
+      use "docker" {
+        image = "bolt-ai"
+        tag   = "production"
+        local = true
+      }
+    }
+  }
+
+  deploy {
+    use "nomad-jobspec" {
+      jobspec = file("${path.app}/nomad/bolt.nomad.hcl")
+    }
+  }
+
+  release {
+    use "nomad-jobspec-canary" {
+      groups = ["bolt-app"]
+      
+      // Canary count is the number of allocations that should be updated at once
+      canary_count = 5
+      
+      // Auto promote determines if waypoint should automatically promote the deployment
+      auto_promote = true
+      
+      // Auto revert determines if waypoint should automatically revert the deployment if it fails
+      auto_revert = true
+      
+      // The amount of time to wait between updating allocations
+      stagger = "30s"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds comprehensive server deployment documentation and implementation to enable GitHub imports functionality in Bolt.DIY.

## Changes

- Added detailed `DEPLOYMENT.md` with instructions for scaling to 200 instances
- Created a server-side Git implementation in `api.server-git.ts`
- Added Docker Swarm configuration for easy scaling
- Added Kubernetes deployment configuration
- Added Nomad job specification for HashiCorp Nomad deployment
- Added Helm chart for Kubernetes deployment
- Added Waypoint configuration for automated deployment
- Created health check endpoint for monitoring
- Added deployment scripts for automating instance creation
- Added Nginx configuration for load balancing

This implementation solves the issue with GitHub imports by moving Git operations to the server side, bypassing browser environment limitations.